### PR TITLE
several improvements + bugfixes in client creation

### DIFF
--- a/tests/mytests.py
+++ b/tests/mytests.py
@@ -1,0 +1,13 @@
+import sys
+sys.path.insert(0,"..")
+from pyrena import *
+from time import sleep
+
+client = Arena(
+    "somearenacustomer@some-company.com",
+    "sqldjsqdlkjsqdldjsqdlk",
+    "some_env"
+    )
+#print(client)
+sleep(5)
+client.logout()


### PR DESCRIPTION
Hi @TheCodeForge ,

Given personal progression on Arena-related development projects, I dove again into your very valuable pyrena package :)
I seem to have found some bugs or outdated bits in the Arena client creation methods.
**My changes are all in the definition of the `Arena` class, in the `__init__.py` file located at the root of the folder.**

Hereafter a summary of these bugfixes and improvements:

#### In `__init__` method:
- added env as a specifyable param by user. if not specified logs into default env
  - l.63 modified `ArenaHTTPError` msg accordingly
  - l.93/95 modified `__repr__` strings accordingly
  - `login` method modified accordingly - `login` data dict differs if `env` is specified
- l.57: set init req remaining to arbitrary high nb: `self._reqs_remaining=123456789`

#### In `login` method:
- l.109 adding `env` in dict keys
- l.111 `login` method modified given introduction of  `env` - `login` data dict differs if `env` is specified
- l.130: workspaceId/name field removed as I think they don't exist anymore

#### In `logout` method:
- l.134: found a bug due to `expect_json=True` by default. Calling `logout` without `expect_json = False` fell into the `else` case l.208 in the `_fetch`method. As no json value was received, it threw me a JSONDecodeError exception. Fixed by specifying `expect_json = False` in `logout` method  -> `self._put("/logout", expect_json = False)`
- l.137 of your original code, "None" value is typo'd: `self._workspace_name=NOne` -> I corrected

#### In `fetch` "canvas" HTTP method:
- renamed all `req` variables into `resp` for more clarity when using response `status_code`, `headers` properties
- l.152: removed quantitative info about the request limit, to limit revealing the "insides" of Arena API to non-customers
- l.192 partially hid exact name of header containing the info on remaining calls, to limit revealing to non-customers.
- l.186 of original code will throw a type error as l.184, `self._reqs_remaining` is a string as is -> needed to be converted into `int` -> Fixed.
- l.187 of original code: chose to print remaining requests at login & logout, rather than just when about to reach the req limit

I tested all these changes in my test > `mytests.py`, with a `sleep` of 5s between calling `client.login()` and `client.logout()` calls [left at PR for evidence - can remove later].

*Further suggestion: suggest to use asyncio & aiohttp instead of requests library, for workflows calling for a succession of endpoints to hit. Basic e.g. of use case: login, and then send how many requests remain, and then do this/do that...*

I'm not so used yet with refined, "commercial-like" PR GitHub workflows as I work in very small teams or on my own most of the time, so please let me know if you need anything else for that PR.
Thanks,